### PR TITLE
Fixes for rails 5.2.3 - 6.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,9 @@ if (moneta_version = ENV["MONETA_VERSION"])
   gem 'moneta', moneta_version
 end
 
-gem 'rspec'
+gem 'rspec', '~> 2.99'
+gem 'crack'
+gem 'pry'
 
 if (wp_version = ENV['WILL_PAGINATE_VERSION'])
   gem 'will_paginate', wp_version

--- a/lib/rocket_pants/client.rb
+++ b/lib/rocket_pants/client.rb
@@ -122,7 +122,10 @@ module RocketPants
     # JSON or HTTParty couldn't parse the response).
     # @param [Hash, Object] response the response to check errors on
     # @raise [RocketPants::Error] a generic error when the type is wrong, or a registered error subclass otherwise.
-    def check_response_errors(response)
+    def check_response_errors(resp)
+      # valid test input can be a HTTParty::Response
+      response = resp.respond_to?(:to_h) ? resp.to_h : resp
+
       if !response.is_a?(Hash)
         raise RocketPants::Error, "The response from the server was not in a supported format."
       elsif response.has_key?("error")

--- a/lib/rocket_pants/controller/jsonp.rb
+++ b/lib/rocket_pants/controller/jsonp.rb
@@ -20,10 +20,10 @@ module RocketPants
         enable = options.delete(:enable) { true }
         param  = options.delete(:parameter).try(:to_sym)
         if enable
-          after_filter :wrap_response_in_jsonp, {:if => :jsonp_is_possible?}.reverse_merge(options)
+          after_action :wrap_response_in_jsonp, {:if => :jsonp_is_possible?}.reverse_merge(options)
           self._jsonp_parameter = param if param
         else
-          skip_after_filter :wrap_response_in_jsonp, options
+          skip_after_action :wrap_response_in_jsonp, options
         end
       end
 
@@ -32,7 +32,8 @@ module RocketPants
     private
 
     def jsonp_is_possible?
-      request.get? && response.content_type == "application/json" && jsonp_parameter.present?
+      # in rails-6 content_type also includes charset
+      request.get? && response.content_type.include?("application/json") && jsonp_parameter.present?
     end
 
     def jsonp_parameter

--- a/lib/rocket_pants/controller/respondable.rb
+++ b/lib/rocket_pants/controller/respondable.rb
@@ -222,7 +222,15 @@ module RocketPants
       {}.tap do |metadata|
         metadata[:count]      = object.length unless singular
         metadata[:pagination] = Respondable.extract_pagination(object) if type == :paginated
-        metadata.merge! options[:metadata] if options[:metadata]
+
+        # special case to allow :metadata params
+        if options[:metadata]
+          if options[:metadata].class.name == "ActionController::Parameters"
+            metadata.merge! options[:metadata].permit!.to_h
+          else
+            metadata.merge! options[:metadata]
+          end
+        end
       end
     end
 

--- a/rocket_pants.gemspec
+++ b/rocket_pants.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.description = "Rocket Pants adds JSON API love to Rails and ActionController, making it simpler to build API-oriented controllers."
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency 'actionpack', '>= 3.0', '< 6.0'
-  s.add_dependency 'railties',   '>= 3.0', '< 6.0'
+  s.add_dependency 'actionpack', '>= 3.0', '< 7.0'
+  s.add_dependency 'railties',   '>= 3.0', '< 7.0'
   s.add_dependency 'will_paginate', '~> 3.0'
   s.add_dependency 'hashie',        '>= 1.0', '< 4'
   s.add_dependency 'api_smith'
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails', '>= 2.4', '< 4.0'
   s.add_development_dependency 'rr',          '~> 1.0'
   s.add_development_dependency 'webmock'
-  s.add_development_dependency 'activerecord', '>= 3.0', '< 6.0'
+  s.add_development_dependency 'activerecord', '>= 3.0', '< 7.0'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'reversible_data', '~> 1.0'
   s.add_development_dependency 'kaminari'

--- a/spec/rocket_pants/controller_spec.rb
+++ b/spec/rocket_pants/controller_spec.rb
@@ -230,7 +230,7 @@ describe RocketPants::Base do
 
     it 'should let you override the content type' do
       stub(TestController).test_data    { {:hello => "World"} }
-      stub(TestController).test_options { {:content_type => Mime::HTML} }
+      stub(TestController).test_options { {:content_type => Mime[:html]} }
       get :test_data
       response.headers['Content-Type'].should =~ /text\/html/
     end


### PR DESCRIPTION
Tests all pass with ruby 2.5.3
Need to lock `rspec` to version 2 and include `crack`
Ultimately we will not merge this into `rails-5.1` but use as a new branch
```
RAILS_VERSION=5.2.3
export RAILS_VERSION
bundle update
rspec

RAILS_VERSION=5.2.4
export RAILS_VERSION
bundle update
rspec

RAILS_VERSION=6.0.1
export RAILS_VERSION
bundle update
rspec
```