### PR TITLE
Update Rocket Pants to support Ruby 3

### DIFF
--- a/lib/rocket_pants/controller/error_handling.rb
+++ b/lib/rocket_pants/controller/error_handling.rb
@@ -55,7 +55,7 @@ module RocketPants
       name    = lookup_error_name(exception)
       message = default_message_for_exception exception
       context = lookup_error_context(exception).reverse_merge(:scope => :"rocket_pants.errors", :default => message)
-      I18n.t name, context.except(:metadata)
+      I18n.t name, **context.except(:metadata)
     end
 
     def default_message_for_exception(exception)


### PR DESCRIPTION
I believe this one line will remove the last Ruby 3 deprecation warning we have from our tests.